### PR TITLE
Added support for restreaming to Facebook

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,14 @@ RTMP_YOUTUBE_ENABLED=false
 RTMP_YOUTUBE_SERVER=rtmp://a.rtmp.youtube.com/live2/
 RTMP_YOUTUBE_KEY=
 
+# Facebook Config
+# Note: Facebook is being connected via rtmps,
+#       which is tunneled via a separate service
+#       in this docker-compose called facebook_rtmps.
+RTMP_FACEBOOK_ENABLED=false
+RTMP_FACEBOOK_SERVER=rtmp://facebook_rtmps:1936/rtmp/
+RTMP_FACEBOOK_KEY=
+
 # Twitch Config
 RTMP_TWITCH_ENABLED=false
 RTMP_TWITCH_SERVER=rtmp://live-mad.twitch.tv/app/

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-MIT License Copyright (c) 2020 Janusz Kamienski
-MIT License Copyright (c) 2020 Horus Lugo (original code)
+MIT License Copyright (c) 2020 Horus Lugo
 
 Permission is hereby granted, free of
 charge, to any person obtaining a copy of this software and associated

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-MIT License Copyright (c) 2020 Horus Lugo
+MIT License Copyright (c) 2020 Janusz Kamienski
+MIT License Copyright (c) 2020 Horus Lugo (original code)
 
 Permission is hereby granted, free of
 charge, to any person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ cp .env.template .env
     - [Configuring YouTube](#Configuring%20YouTube)
     - [Configuring Twitch](#Configuring%20Twitch)
     - [Configuring Periscope](#Configuring%20Periscope)
+    - [Configuring Facebook](#Configuring%20Facebook)
 
 ⚠️ &nbsp;**Make sure to use a strong `RTMP_SECRET` if you plan to expose the server to the internet.**
 
@@ -114,6 +115,21 @@ We can also find the `Server URL` that we should place in the **`RTMP_PERISCOPE_
 ⚠️ &nbsp;**Remember setting the `RTMP_PERISCOPE_ENABLED` to `true`**
 
 ---
+
+## Configuring Facebook
+
+_Here is stated how you can get the parameters to fill the **Facebook** section of your `.env` file._
+
+Go to the Facebook Live Producer page following this link: https://www.facebook.com/live/producer/.
+Select proper space you will post your live (your timeline or facebook page). In the main section you will find your `Stream Key`. We should place it
+in the **`RTMP_FACEBOOK_KEY`** variable.
+
+We can also find the `Server URL`, but Facebook at this point uses only one URL: `live-api-s.facebook.com:443`. It is set for SSL tunneling in the stunnel4 config, so there's no need to adjust this.
+
+⚠️ &nbsp;**Remember setting the `RTMP_FACEBOOK_ENABLED` to `true`**
+
+---
+
 
 ## Support me
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ $ cp .env.template .env
 
 4. Open and fill the `.env` file and fill it with the configuration for the platforms you want to stream.
 
-    - [Configuring YouTube](#Configuring%20YouTube)
-    - [Configuring Twitch](#Configuring%20Twitch)
-    - [Configuring Periscope](#Configuring%20Periscope)
-    - [Configuring Facebook](#Configuring%20Facebook)
+    - [Configuring YouTube](#configuring-youtube)
+    - [Configuring Twitch](#configuring-twitch)
+    - [Configuring Periscope](#configuring-periscope)
+    - [Configuring Facebook](#configuring-facebook)
 
 ⚠️ &nbsp;**Make sure to use a strong `RTMP_SECRET` if you plan to expose the server to the internet.**
 

--- a/create-nginx-conf.sh
+++ b/create-nginx-conf.sh
@@ -24,6 +24,17 @@ if [ "$RTMP_TWITCH_ENABLED" == "true" ] && [ "$RTMP_TWITCH_KEY" != "" ]; then
   "
 fi
 
+
+FACEBOOK_CONFIG=""
+
+if [ "$RTMP_FACEBOOK_ENABLED" == "true" ] && [ "$RTMP_FACEBOOK_KEY" != "" ]; then
+  TWITCH_CONFIG="
+    # Facebook
+    push $RTMP_FACEBOOK_SERVER$RTMP_FACEBOOK_KEY;
+  "
+fi
+
+
 YOUTUBE_CONFIG=""
 
 if [ "$RTMP_YOUTUBE_ENABLED" == "true" ] && [ "$RTMP_YOUTUBE_KEY" != "" ]; then
@@ -50,6 +61,7 @@ rtmp {
 
       $PERISCOPE_CONFIG
       $TWITCH_CONFIG
+      $FACEBOOK_CONFIG
       $YOUTUBE_CONFIG
     }
   }

--- a/create-nginx-conf.sh
+++ b/create-nginx-conf.sh
@@ -28,7 +28,7 @@ fi
 FACEBOOK_CONFIG=""
 
 if [ "$RTMP_FACEBOOK_ENABLED" == "true" ] && [ "$RTMP_FACEBOOK_KEY" != "" ]; then
-  TWITCH_CONFIG="
+  FACEBOOK_CONFIG="
     # Facebook
     push $RTMP_FACEBOOK_SERVER$RTMP_FACEBOOK_KEY;
   "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3.7"
+
 services:
   rtmp:
     build: .
@@ -8,3 +9,5 @@ services:
   rtmp-auth:
     build: ./auth
     env_file: .env
+  facebook_rtmps:
+    build: ./facebook-tunnel

--- a/facebook-tunnel/Dockerfile
+++ b/facebook-tunnel/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y stunnel4
+
+COPY ./stunnel.conf /etc/stunnel/stunnel.conf
+COPY ./stunnel4 /etc/default/stunnel4
+
+EXPOSE 1936
+
+CMD ["stunnel"]

--- a/facebook-tunnel/stunnel.conf
+++ b/facebook-tunnel/stunnel.conf
@@ -1,0 +1,18 @@
+pid = /var/run/stunnel4/stunnel.pid
+output = /var/log/stunnel4/stunnel.log
+foreground = yes
+
+setuid = stunnel4
+setgid = stunnel4
+
+# https://www.stunnel.org/faq.html
+socket = r:TCP_NODELAY=1
+socket = l:TCP_NODELAY=1
+
+debug = 4
+
+[facebook-live]
+client = yes
+accept = 1936
+connect = live-api-s.facebook.com:443
+verifyChain = no

--- a/facebook-tunnel/stunnel4
+++ b/facebook-tunnel/stunnel4
@@ -1,0 +1,18 @@
+# /etc/default/stunnel
+# Julien LEMOINE <speedblue@debian.org>
+# September 2003
+
+# Change to one to enable stunnel automatic startup
+ENABLED=1
+FILES="/etc/stunnel/*.conf"
+OPTIONS=""
+
+# Change to one to enable ppp restart scripts
+PPP_RESTART=0
+
+# Change to enable the setting of limits on the stunnel instances
+# For example, to set a large limit on file descriptors (to enable
+# more simultaneous client connections), set RLIMITS="-n 4096"
+# More than one resource limit may be modified at the same time,
+# e.g. RLIMITS="-n 4096 -d unlimited"
+RLIMITS=""


### PR DESCRIPTION
I found this project really clean and easy to use for the needs of my group streaming online meetup. But it lacked Facebook Live support. So I decided to extend it and share it with others via PR. 

The main issue with providing restreaming to Facebook is that the service only allows connections via `rtmps` (secured) connection, which is not easy to achieve as with Twitch/YouTube or others. I have extended this project by adding `stunnel4` tool which is tunnelling the connection from the regular to the secure one on the selected ports. This version does not support setting up the Server URL, but for Facebook, it is constant.

- added `Dockerfile` for building `stunnel4` service for Facebook support
- added proper entry for service in the `docker-compose`
- added `nginx` configuration section
- added `README` section on Facebook configuration

Tested and used by @pykonik - our local Python Community in Krakow, Poland :) 